### PR TITLE
Minor cleanup of retry class

### DIFF
--- a/lib/active_job/retry.rb
+++ b/lib/active_job/retry.rb
@@ -12,7 +12,7 @@ module ActiveJob
     #                retry_exceptions: [TimeoutError]  # default nil, i.e. all
     #
     #     def perform(url, web_hook_id, hmac_key)
-    #       work!
+    #       # Do work
     #     end
     #   end
     def self.included(base)
@@ -20,14 +20,13 @@ module ActiveJob
     end
 
     module ClassMethods
-      # Setup DSL
       def retry_with(options)
         OptionsValidator.new(options).validate!
 
-        @retry_limit      = options[:limit]            if options[:limit]
-        @retry_delay      = options[:delay]            if options[:delay]
-        @fatal_exceptions = options[:fatal_exceptions] if options[:fatal_exceptions]
-        @retry_exceptions = options[:retry_exceptions] if options[:retry_exceptions]
+        @retry_limit      = options[:limit]
+        @retry_delay      = options[:delay]
+        @fatal_exceptions = options[:fatal_exceptions]
+        @retry_exceptions = options[:retry_exceptions]
       end
 
       ############

--- a/lib/active_job/retry/exponential_backoff.rb
+++ b/lib/active_job/retry/exponential_backoff.rb
@@ -43,17 +43,17 @@ module ActiveJob
           retry_with(options)
           ExponentialOptionsValidator.new(options).validate!
 
-          @retry_limit          = options[:limit] || options[:strategy].length if options[:strategy]
-          @backoff_strategy     = options[:strategy]             if options[:strategy]
-          @min_delay_multiplier = options[:min_delay_multiplier] if options[:min_delay_multiplier]
-          @max_delay_multiplier = options[:max_delay_multiplier] if options[:max_delay_multiplier]
+          @retry_limit          = options[:limit] || options[:strategy].try(:length)
+          @backoff_strategy     = options[:strategy]
+          @min_delay_multiplier = options[:min_delay_multiplier]
+          @max_delay_multiplier = options[:max_delay_multiplier]
         end
 
         ############
         # Defaults #
         ############
         def retry_limit
-          @retry_limit ||= (backoff_strategy || []).length
+          @retry_limit ||= backoff_strategy.try(:length)
         end
 
         def backoff_strategy


### PR DESCRIPTION
- Instance variables default to `nil`, so there's no need to check whether we're assigning them to `nil`
- Requiring `ActiveJob` means we have access to `ActiveSupport`. We may as well use it!