### PR TITLE
Support Ruby 1.9.3

### DIFF
--- a/lib/active_job/retry/exponential_options_validator.rb
+++ b/lib/active_job/retry/exponential_options_validator.rb
@@ -1,7 +1,10 @@
 module ActiveJob
   module Retry
     class ExponentialOptionsValidator
-      DELAY_MULTIPLIER_KEYS = %i(min_delay_multiplier max_delay_multiplier).freeze
+      DELAY_MULTIPLIER_KEYS = [
+        :min_delay_multiplier,
+        :max_delay_multiplier
+      ].freeze
 
       def initialize(options)
         @options = options


### PR DESCRIPTION
No `%i()` in Ruby 1.9.3.