### PR TITLE
Use nil for unlimited retries

### DIFF
--- a/lib/active_job/retry/constant_backoff_strategy.rb
+++ b/lib/active_job/retry/constant_backoff_strategy.rb
@@ -26,7 +26,7 @@ module ActiveJob
       attr_reader :retry_limit, :fatal_exceptions, :retry_exceptions
 
       def retry_limit_reached?(attempt)
-        return false if retry_limit == -1
+        return false unless retry_limit
         attempt >= retry_limit
       end
 

--- a/spec/retry/constant_backoff_strategy_spec.rb
+++ b/spec/retry/constant_backoff_strategy_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ActiveJob::Retry::ConstantBackoffStrategy do
     let(:exception) { RuntimeError.new }
 
     context 'when the limit is infinite' do
-      let(:options) { { limit: -1, infinite_job: true } }
+      let(:options) { { limit: nil, unlimited_retries: true } }
 
       context '1st attempt' do
         let(:attempt) { 1 }

--- a/spec/retry/constant_options_validator_spec.rb
+++ b/spec/retry/constant_options_validator_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe ActiveJob::Retry::ConstantOptionsValidator do
   subject(:validate!) { -> { validator.validate! } }
 
   context 'valid options' do
-    context 'infinite retries' do
-      let(:options) { { limit: -1, infinite_job: true } }
+    context 'unlimited retries' do
+      let(:options) { { limit: nil, unlimited_retries: true } }
       it { is_expected.to_not raise_error }
     end
 
@@ -44,12 +44,17 @@ RSpec.describe ActiveJob::Retry::ConstantOptionsValidator do
 
   context 'invalid options' do
     context 'bad limit' do
-      let(:options) { { limit: -2 } }
+      let(:options) { { limit: -1 } }
       it { is_expected.to raise_error(ActiveJob::Retry::InvalidConfigurationError) }
     end
 
     context 'accidental infinite limit' do
-      let(:options) { { limit: -1 } }
+      let(:options) { { limit: nil } }
+      it { is_expected.to raise_error(ActiveJob::Retry::InvalidConfigurationError) }
+    end
+
+    context 'accidental finite limit' do
+      let(:options) { { unlimited_retries: true } }
       it { is_expected.to raise_error(ActiveJob::Retry::InvalidConfigurationError) }
     end
 


### PR DESCRIPTION
Use `nil`, rather than `-1`, for unlimited retries. `limit` still defaults to `1` if not specified.