### PR TITLE
Clarify that delay times are measured in seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ class ProcessWebhook < ActiveJob::Base
   queue_as :webhooks
 
   # Constant delay between attempts:
-  constant_retry limit: 3, delay: 5, retryable_exceptions: [TimeoutError, NetworkError]
+  constant_retry limit: 3, delay: 5.minutes, retryable_exceptions: [TimeoutError, NetworkError]
 
   # Or, variable delay between attempts:
-  variable_retry delays: [1, 5, 10, 30]
+  variable_retry delays: [1.minute, 5.minutes, 10.minutes, 30.minutes]
 
   # You can also use a custom backoff strategy by passing an object which responds to
   # `should_retry?(attempt, exception)`, and `retry_delay(attempt, exception)`
@@ -48,7 +48,7 @@ if the exception is not going to be retried, or has failed the final retry.
 |:---------------------- |:------- |:-------------- |
 | `limit`                | `1`     | Maximum number of times to attempt the job (default: 1).
 | `unlimited_retries`    | `false` | If set to `true`, this job will be repeated indefinitely until in succeeds. Use with extreme caution.
-| `delay`                | `0`     | Time between attempts (default: 0).
+| `delay`                | `0`     | Time between attempts in seconds (default: 0).
 | `retryable_exceptions` | `nil`   | A whitelist of exceptions to retry. When `nil`, all exceptions will result in a retry.
 | `fatal_exceptions`     | `[]`    | A blacklist of exceptions to not retry (default: []).
 
@@ -56,7 +56,7 @@ if the exception is not going to be retried, or has failed the final retry.
 
 | Option                 | Default | Description   |
 |:---------------------- |:------- |:------------- |
-| `delays`               |         | __required__ An array of delays between attempts. The first attempt will occur whenever you originally enqueued the job to happen.
+| `delays`               |         | __required__ An array of delays between attempts in seconds. The first attempt will occur whenever you originally enqueued the job to happen.
 | `min_delay_multiplier` |         | If supplied, each delay will be multiplied by a random number between this and `max_delay_multiplier`.
 | `max_delay_multiplier` |         | The other end of the range for `min_delay_multiplier`. If one is supplied, both must be.
 | `retryable_exceptions` | `nil`   | Same as for [constant_retry](#constant_retry-options).


### PR DESCRIPTION
It's not too clear in the readme at the moment that delay times are in seconds.

Am I right that they are? Looks like that's the case from <http://api.rubyonrails.org/classes/ActiveJob/Enqueuing.html>