### PR TITLE
As of version `3.1.0` QC supports `enqueue_at`

### DIFF
--- a/lib/active_job/retry.rb
+++ b/lib/active_job/retry.rb
@@ -16,7 +16,6 @@ module ActiveJob
     PROBLEMATIC_ADAPTERS = [
       'ActiveJob::QueueAdapters::InlineAdapter',
       'ActiveJob::QueueAdapters::QuAdapter',
-      'ActiveJob::QueueAdapters::QueueClassicAdapter',
       'ActiveJob::QueueAdapters::SneakersAdapter',
       'ActiveJob::QueueAdapters::SuckerPunchAdapter'
     ].freeze


### PR DESCRIPTION
The latest version of queue_classic does support `enqueue_at`.

See https://github.com/QueueClassic/queue_classic/pull/217

For QC users with versions older than `3.1.0` this patch could lead to harder to debug problems.
I still feel that it's the responsibility of Active Job to bark when something isn't supported.